### PR TITLE
Move to ripe.net REST api

### DIFF
--- a/nginx-acl.sh
+++ b/nginx-acl.sh
@@ -15,8 +15,8 @@ if [[ -z "$rule" ]] || [[ -z "$asn" ]]; then
 fi
 
 curl -sS --fail "https://stat.ripe.net/data/as-overview/data.json?resource=AS{$asn}&sourceapp=nginx-acl" \
-    | jq -r '"# AS" + .data.resource + ", " + .data.holder + ", " + .time' 
+    | jq -r '"# AS" + .data.resource + ", " + .data.holder + ", " + .time'
 
-curl -sS --fail "https://stat.ripe.net/data/announced-prefixes/data.json?resource=AS${asn}&sourceapp=nginx-acl" \
-    | jq -r '.data.prefixes | map(.prefix) | .[]' \
+curl -H 'Accept: application/json' -sS --fail "https://rest.db.ripe.net/search?source=ripe&type-filter=route,route6&inverse-attribute=origin&query-string=AS${asn}" \
+    | jq -r '.objects.object[]."primary-key".attribute[] | select(.name != "origin") | .value' \
     | xargs -I% echo "${rule} %;"


### PR DESCRIPTION
Sometimes stat.ripe.net does not return all announced routes. The move to the REST api of ripe.net will actually return all routes of the AS.

An example of this is:
route6:         2a01:c000::/19
descr:          Orange S.A.
origin:         AS5511

This subnet is completely missing from the stat.ripe.net output.